### PR TITLE
build: use memory_manager.c in CMake and setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(include)
 add_library(GameTrainerLib SHARED
         src/c/input.c
 #        src/c/memory_ops.c  # Adjust path as needed
-        sec/c/memory.c
+        src/c/memory_manager.c
 
 )
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     ext_modules=[
         Extension(
             "gametrainer.clib",
-            ["src/c/memory.c", "src/c/input.c"],
+            ["src/c/memory_manager.c", "src/c/input.c"],
             include_dirs=["include"],
         )
     ],


### PR DESCRIPTION
## Summary
- use `memory_manager.c` instead of non-existent `memory.c` in CMake
- update `setup.py` to compile with `memory_manager.c`

## Testing
- `python -m py_compile $(find src/python -name '*.py') main.py`
- `cmake -B build`
- `cmake --build build` *(fails: Windows.h missing)*
- `python setup.py build` *(fails: Windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d0a120d2c832280fadaa4500d08ff